### PR TITLE
Support standard ortho4x12 QMK layout

### DIFF
--- a/houndstooth/houndstooth.h
+++ b/houndstooth/houndstooth.h
@@ -3,7 +3,7 @@
 
 #include "quantum.h"
 
-#define LAYOUT( \
+#define LAYOUT_ortho_4x12( \
 	K00, K01, K02, K03, K04, K05, K40, K41, K42, K43, K44, K45,\
 	K10, K11, K12, K13, K14, K15, K50, K51, K52, K53, K54, K55,\
 	K20, K21, K22, K23, K24, K25, K60, K61, K62, K63, K64, K65,\
@@ -18,5 +18,7 @@
 	{ K60,   K61,   K62,   K63,   K64,   K65 }, \
 	{ K70,   K71,   K72,   K73,   K74,   K75 }  \
 }
+
+#define LAYOUT LAYOUT_ortho_4x12
 
 #endif

--- a/houndstooth/rules.mk
+++ b/houndstooth/rules.mk
@@ -40,6 +40,8 @@ OPT_DEFS += -DINTERRUPT_CONTROL_ENDPOINT
 # Boot Section Size in *bytes*
 OPT_DEFS += -DBOOTLOADER_SIZE=4096
 
+# Supported qmk layouts
+LAYOUTS = ortho_4x12
 
 # Build Options
 #   comment out to disable the options.


### PR DESCRIPTION
QMK allows layouts to be shared across boards with the same physical
layouts (e.g. planck and houndstooth), which is really useful if you own
more than one board and want to have the same key mappings on each.

Supporting is straightforward, just the declaration in rules.mk and a
layout declaration which matches the convention. It doesn't affect
builds which don't want to use it, and which just create a new keymap.c.

https://beta.docs.qmk.fm/features/feature_layouts